### PR TITLE
Add meta-redirect to challenge platform. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
 	<meta property="og:description" content="Cyber Security Challenge Germany 2025 Qualifiers">
 	<meta property="og:image" content="https://cscg.live/cscg.png">
 
+	<meta http-equiv="refresh" content="0; URL=https://play.cscg.live">
+
 	<link rel="icon" href="favicon.ico" type="image/x-icon"/>
 	<link rel="shortcut icon" href="favicon.ico" type="image/x-icon"/>
 	<link href="https://cdn.jsdelivr.net/npm/@patternfly/patternfly@2.6.5/patternfly.min.css"


### PR DESCRIPTION
github pages does not support 301 redirects.